### PR TITLE
fix castbar ticks & add user option for it

### DIFF
--- a/Quartz/Player/Player.lua
+++ b/Quartz/Player/Player.lua
@@ -348,6 +348,9 @@ local function setBarTicks(ticknum)
 
          	t:SetHeight(db.profile.h*1.0) -- Height of ticks based on castbar size.
 
+
+			--== Animation for ticks to fade-in, alpha is adjustable by user settings in option frame ==--			
+
 			local tickalpha = Quartz.db.profile.tickalpha.value
 
 			UIFrameFadeIn(t, FadeInTime, 0, tickalpha)

--- a/Quartz/Player/Player.lua
+++ b/Quartz/Player/Player.lua
@@ -14,183 +14,185 @@
 	You should have received a copy of the GNU General Public License along
 	with this program; if not, write to the Free Software Foundation, Inc.,
 	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-]]
-local L = AceLibrary("AceLocale-2.2"):new("Quartz")
+	]]
+	local L = AceLibrary("AceLocale-2.2"):new("Quartz")
 
-local Quartz = Quartz
-if Quartz:HasModule('Player') then
-	return
-end
-local QuartzPlayer = Quartz:NewModule('Player')
-local self = QuartzPlayer
-
-local media = LibStub("LibSharedMedia-3.0")
-
-local math_min = math.min
-local unpack = unpack
-local tonumber = tonumber
-local UnitCastingInfo = UnitCastingInfo
-local UnitChannelInfo = UnitChannelInfo
-local GetTime = GetTime
-local castTimeFormatString
-
-local castBar, castBarText, castBarTimeText, castBarIcon, castBarSpark, castBarParent, db
-
-local function timenum(num, isCastTime)
-	if num <= 60 then
-		if isCastTime then
-			return (castTimeFormatString):format(num)
-		else
-			return ('%.1f'):format(num)
-		end
-	else
-		return ('%d:%02d'):format(num / 60, num % 60)
+	local Quartz = Quartz
+	if Quartz:HasModule('Player') then
+		return
 	end
-end
-local function OnUpdate()
-	local currentTime = GetTime()
-	local startTime = self.startTime
-	local endTime = self.endTime
-	local delay = self.delay
-	if self.casting then
-		if currentTime > endTime then
-			self.casting = nil
-			self.fadeOut = true
-			self.stopTime = currentTime
-		end
-		
-		local showTime = math_min(currentTime, endTime)
-		
-		local perc = (showTime-startTime) / (endTime - startTime)
-		castBar:SetValue(perc)
-		castBarSpark:ClearAllPoints()
-		castBarSpark:SetPoint('CENTER', castBar, 'LEFT', perc * db.profile.w, 0)
-		
-		if delay and delay ~= 0 then
-			if db.profile.hidecasttime then
-				castBarTimeText:SetText(("|cffff0000+%.1f|cffffffff %s"):format(delay, timenum(endTime - showTime)))
+	local QuartzPlayer = Quartz:NewModule('Player')
+	local self = QuartzPlayer
+
+	local media = LibStub("LibSharedMedia-3.0")
+
+	local math_min = math.min
+	local unpack = unpack
+	local tonumber = tonumber
+	local UnitCastingInfo = UnitCastingInfo
+	local UnitChannelInfo = UnitChannelInfo
+	local GetTime = GetTime
+	local castTimeFormatString
+
+	local castBar, castBarText, castBarTimeText, castBarIcon, castBarSpark, castBarParent, db
+
+	local function timenum(num, isCastTime)
+		if num <= 60 then
+			if isCastTime then
+				return (castTimeFormatString):format(num)
 			else
-				castBarTimeText:SetText(("|cffff0000+%.1f|cffffffff %s / %s"):format(delay, timenum(endTime - showTime), timenum(endTime - startTime, true)))
+				return ('%.1f'):format(num)
 			end
 		else
-			if db.profile.hidecasttime then
-				castBarTimeText:SetText(timenum(endTime - showTime))
-			else
-				castBarTimeText:SetText(("%s / %s"):format(timenum(endTime - showTime), timenum(endTime - startTime, true)))
+			return ('%d:%02d'):format(num / 60, num % 60)
+		end
+	end
+	local function OnUpdate()
+		local currentTime = GetTime()
+		local startTime = self.startTime
+		local endTime = self.endTime
+		local delay = self.delay
+		if self.casting then
+			if currentTime > endTime then
+				self.casting = nil
+				self.fadeOut = true
+				self.stopTime = currentTime
 			end
-		end
-	elseif self.channeling then
-		if currentTime > endTime then
-			self.channeling = nil
-			self.fadeOut = true
-			self.stopTime = currentTime
-		end
-		local remainingTime = endTime - currentTime
-		local perc = remainingTime / (endTime - startTime)
-		castBar:SetValue(perc)
-		castBarTimeText:SetText(("%.1f"):format(remainingTime))
-		castBarSpark:ClearAllPoints()
-		castBarSpark:SetPoint('CENTER', castBar, 'LEFT', perc * db.profile.w, 0)
-		
-		if delay and delay ~= 0 then
-			if db.profile.hidecasttime then
-				castBarTimeText:SetText(("|cffFF0000-%.1f|cffffffff %s"):format(delay, timenum(remainingTime)))
+
+			local showTime = math_min(currentTime, endTime)
+
+			local perc = (showTime-startTime) / (endTime - startTime)
+			castBar:SetValue(perc)
+			castBarSpark:ClearAllPoints()
+			castBarSpark:SetPoint('CENTER', castBar, 'LEFT', perc * db.profile.w, 0)
+
+			if delay and delay ~= 0 then
+				if db.profile.hidecasttime then
+					castBarTimeText:SetText(("|cffff0000+%.1f|cffffffff %s"):format(delay, timenum(endTime - showTime)))
+				else
+					castBarTimeText:SetText(("|cffff0000+%.1f|cffffffff %s / %s"):format(delay, timenum(endTime - showTime), timenum(endTime - startTime, true)))
+				end
 			else
-				castBarTimeText:SetText(("|cffFF0000-%.1f|cffffffff %s / %s"):format(delay, timenum(remainingTime), timenum(endTime - startTime, true)))
+				if db.profile.hidecasttime then
+					castBarTimeText:SetText(timenum(endTime - showTime))
+				else
+					castBarTimeText:SetText(("%s / %s"):format(timenum(endTime - showTime), timenum(endTime - startTime, true)))
+				end
+			end
+		elseif self.channeling then
+			if currentTime > endTime then
+				self.channeling = nil
+				self.fadeOut = true
+				self.stopTime = currentTime
+			end
+			local remainingTime = endTime - currentTime
+			local perc = remainingTime / (endTime - startTime)
+			castBar:SetValue(perc)
+			castBarTimeText:SetText(("%.1f"):format(remainingTime))
+			castBarSpark:ClearAllPoints()
+			castBarSpark:SetPoint('CENTER', castBar, 'LEFT', perc * db.profile.w, 0)
+
+			if delay and delay ~= 0 then
+				if db.profile.hidecasttime then
+					castBarTimeText:SetText(("|cffFF0000-%.1f|cffffffff %s"):format(delay, timenum(remainingTime)))
+				else
+					castBarTimeText:SetText(("|cffFF0000-%.1f|cffffffff %s / %s"):format(delay, timenum(remainingTime), timenum(endTime - startTime, true)))
+				end
+			else
+				if db.profile.hidecasttime then
+					castBarTimeText:SetText(timenum(remainingTime))
+				else
+					castBarTimeText:SetText(("%s / %s"):format(timenum(remainingTime), timenum(endTime - startTime, true)))
+				end
+			end
+		elseif self.fadeOut then
+			castBarSpark:Hide()
+			local alpha
+			local stopTime = self.stopTime
+			if stopTime then
+				alpha = stopTime - currentTime + 1
+			else
+				alpha = 0
+			end
+			if alpha >= 1 then
+				alpha = 1
+			end
+			if alpha <= 0 then
+				self.stopTime = nil
+				castBarParent:Hide()
+			else
+				castBarParent:SetAlpha(alpha*db.profile.alpha)
 			end
 		else
-			if db.profile.hidecasttime then
-				castBarTimeText:SetText(timenum(remainingTime))
-			else
-				castBarTimeText:SetText(("%s / %s"):format(timenum(remainingTime), timenum(endTime - startTime, true)))
-			end
-		end
-	elseif self.fadeOut then
-		castBarSpark:Hide()
-		local alpha
-		local stopTime = self.stopTime
-		if stopTime then
-			alpha = stopTime - currentTime + 1
-		else
-			alpha = 0
-		end
-		if alpha >= 1 then
-			alpha = 1
-		end
-		if alpha <= 0 then
-			self.stopTime = nil
 			castBarParent:Hide()
-		else
-			castBarParent:SetAlpha(alpha*db.profile.alpha)
+		end
+	end
+	QuartzPlayer.OnUpdate = OnUpdate
+	local function OnHide()
+		if Quartz:HasModule('Latency') and Quartz:IsModuleActive('Latency') then
+			local ql = Quartz:GetModule('Latency')
+			if ql.lagbox then
+				ql.lagbox:Hide()
+				ql.lagtext:Hide()
+			end
+		end
+		castBarParent:SetScript('OnUpdate', nil)
+	end
+
+	local function OnShow()
+		castBarParent:SetScript('OnUpdate', OnUpdate)
+	end
+
+	local setnametext
+	do
+	local numerals = { -- 25's enough for now, I think?
+	'I', 'II', 'III', 'IV', 'V',
+	'VI', 'VII', 'VIII', 'IX', 'X',
+	'XI', 'XII', 'XIII', 'XIV', 'XV',
+	'XVI', 'XVII', 'XVIII', 'XIX', 'XX',
+	'XXI', 'XXII', 'XXIII', 'XXIV', 'XXV',
+}
+function setnametext(name, rank)
+	if db.profile.spellrank and rank then
+		local rankstyle = db.profile.spellrankstyle
+		if rankstyle == L["Number"] then
+			local num = tonumber(rank:match(L["Rank (%d+)"]))
+			if num and num > 0 then
+				castBarText:SetText(("%s %d"):format(name, num))
+			else
+				castBarText:SetText(name)
+			end
+		elseif rankstyle == L["Full Text"] then
+			local num = tonumber(rank:match(L["Rank (%d+)"]))
+			if num and num > 0 then
+				castBarText:SetText(("%s (%s)"):format(name, rank))
+			else
+				castBarText:SetText(name)
+			end
+		elseif rankstyle == L["Roman"] then
+			local num = tonumber(rank:match(L["Rank (%d+)"]))
+			if num and num > 0 then
+				castBarText:SetText(("%s %s"):format(name, numerals[num]))
+			else
+				castBarText:SetText(name)
+			end
+			else -- L["Roman Full Text"]
+			local num = tonumber(rank:match(L["Rank (%d+)"]))
+			if num and num > 0 then
+				castBarText:SetText(("%s (%s)"):format(name, L["Rank %s"]:format(numerals[num])))
+			else
+				castBarText:SetText(("%s (%s)"):format(name, rank))
+			end
 		end
 	else
-		castBarParent:Hide()
+		castBarText:SetText(name)
+	end
+
+	if db.profile.targetname and self.targetName and (self.targetName ~= '') then
+		local castText = castBarText:GetText() or nil
+		if castText then castBarText:SetText(castText .. " -> " .. self.targetName) end
 	end
 end
-QuartzPlayer.OnUpdate = OnUpdate
-local function OnHide()
-	if Quartz:HasModule('Latency') and Quartz:IsModuleActive('Latency') then
-		local ql = Quartz:GetModule('Latency')
-		if ql.lagbox then
-			ql.lagbox:Hide()
-			ql.lagtext:Hide()
-		end
-	end
-	castBarParent:SetScript('OnUpdate', nil)
-end
-local function OnShow()
-	castBarParent:SetScript('OnUpdate', OnUpdate)
-end
-local setnametext
-do
-	local numerals = { -- 25's enough for now, I think?
-		'I', 'II', 'III', 'IV', 'V',
-		'VI', 'VII', 'VIII', 'IX', 'X',
-		'XI', 'XII', 'XIII', 'XIV', 'XV',
-		'XVI', 'XVII', 'XVIII', 'XIX', 'XX',
-		'XXI', 'XXII', 'XXIII', 'XXIV', 'XXV',
-	}
-	function setnametext(name, rank)
-		if db.profile.spellrank and rank then
-			local rankstyle = db.profile.spellrankstyle
-			if rankstyle == L["Number"] then
-				local num = tonumber(rank:match(L["Rank (%d+)"]))
-				if num and num > 0 then
-					castBarText:SetText(("%s %d"):format(name, num))
-				else
-					castBarText:SetText(name)
-				end
-			elseif rankstyle == L["Full Text"] then
-				local num = tonumber(rank:match(L["Rank (%d+)"]))
-				if num and num > 0 then
-					castBarText:SetText(("%s (%s)"):format(name, rank))
-				else
-					castBarText:SetText(name)
-				end
-			elseif rankstyle == L["Roman"] then
-				local num = tonumber(rank:match(L["Rank (%d+)"]))
-				if num and num > 0 then
-					castBarText:SetText(("%s %s"):format(name, numerals[num]))
-				else
-					castBarText:SetText(name)
-				end
-			else -- L["Roman Full Text"]
-				local num = tonumber(rank:match(L["Rank (%d+)"]))
-				if num and num > 0 then
-					castBarText:SetText(("%s (%s)"):format(name, L["Rank %s"]:format(numerals[num])))
-				else
-					castBarText:SetText(("%s (%s)"):format(name, rank))
-				end
-			end
-		else
-			castBarText:SetText(name)
-		end
-		
-		if db.profile.targetname and self.targetName and (self.targetName ~= '') then
-			local castText = castBarText:GetText() or nil
-			if castText then castBarText:SetText(castText .. " -> " .. self.targetName) end
-		end
-	end
 end
 
 
@@ -281,19 +283,27 @@ function QuartzPlayer:OnEnable()
 	Quartz.ApplySettings()
 end
 
+
+----------------------------------------------------------------------
+--	Cast Bar - Spark and Ticks.
+----------------------------------------------------------------------
+
+
+--===== Create Spark, but this is not where you can change its visual, to chang visual do Ctrl+F SparkVisual  =====--
+
 local sparkfactory = {
 
 	__index = function(t,k)		local spark = castBar:CreateTexture(nil, 'OVERLAY')
 
 		t[k] = 	spark
 
-		spark:SetTexture("Interface\\CastingBar\\UI-CastingBar-Spark")
+		spark:SetTexture("Interface\\CastingBar\\UI-CastingBar-Spark") -- Texture of spark.
 
 		spark:SetVertexColor(unpack(Quartz.db.profile.sparkcolor))
 
 		spark:SetBlendMode('ADD')
 
-		spark:SetWidth(20)
+		spark:SetWidth(50) -- Not sure why can't change spark width.
 
 		spark:SetHeight(db.profile.h*2.2)
 
@@ -303,41 +313,62 @@ local sparkfactory = {
 
 }
 
+
+
+--===== Create Ticks Function =====--
+
 local barticks = setmetatable({}, sparkfactory)
 
+--== Animation time of ticks fade-in and fade-out ==--
+local FadeInTime = 0.2 -- Change this value as needed
+
 local function setBarTicks(ticknum)
+    if (ticknum and ticknum > 0) then
+        local delta = (db.profile.w / ticknum)
 
-	if( ticknum and ticknum > 0) then
+        for k = 1,ticknum -1 do -- Added "-1" value to remove the first tick visual at the start position of Channeling Spell castbar.
+            local t = barticks[k] -- this is where ticks are created.
 
-		local delta = ( db.profile.w / ticknum )
-
-		for k = 1,ticknum do
-
-			local t = barticks[k]
-
+            --== Here we setup the positions, texture, color of Ticks.
+            
 			t:ClearAllPoints()
+			t:SetPoint("CENTER", castBar, "LEFT", delta * k, 0 )			
+		    
+		    t:SetTexture("Interface\\BUTTONS\\WHITE8X8.blp") 
+			
+	       	local r,g,b,a=unpack(Quartz.db.profile.sparkcolor) 
 
-			t:SetPoint("CENTER", castBar, "LEFT", delta * k, 0 )
 
-			t:Show()
 
-		end
+         	t:SetVertexColor(r,g,b,a) 
 
-	else
+          	t:SetBlendMode('BLEND')
 
-		barticks[1].Hide = nil
+         	t:SetWidth(2)
 
-		for _, v in ipairs(barticks) do
+         	t:SetHeight(db.profile.h*1.0) -- Height of ticks based on castbar size.
 
-			v:Hide()
+			local tickalpha = Quartz.db.profile.tickalpha.value
 
-		end
+			UIFrameFadeIn(t, FadeInTime, 0, tickalpha)
 
-	end
+        	t:Show()
+        end
+    else
+    	barticks[1].Hide=nil
 
+      	for _, v in ipairs(barticks) do
+      		v:Hide()
+      end
+      
+   end
+   
 end
 
 Quartz.setBarTicks = setBarTicks
+
+
+--===== Some events =====--
 
 function QuartzPlayer:UNIT_SPELLCAST_SENT(unit, spell, rank, target)
 	if unit ~= 'player' then
@@ -392,63 +423,139 @@ function QuartzPlayer:UNIT_SPELLCAST_START(unit)
 	end
 end
 
+
+--===== Data for Channeling Ticks =====---
+
 local channelData, channelingTicks = {
-    -- warlock
-    [1120] = 5, -- drain soul
-    [689] = 5, -- drain life
-    [5138] = 5, -- drain mana
-    [5740] = 4, -- rain of fire
-    [755] = 10, -- health funnel
-    [1949] = 15, -- hellfire
-    -- druid
-    [740] = 4, -- Tranquility
-    [16914] = 10, -- Hurricane
-    -- priest
-    [15407] = 3, -- mind flay
-    
-    -- mage
-    [12051] = 4, -- Evocation
-    -- [5143] = 3, -- arcane missiles r1
-    -- [5144] = 4, -- arcane missiles r2
-    [5145] = 5, -- arcane missiles
-    [10] = 8, -- blizzard
-    -- hunter
-    [1510] = 6, -- volley
-    -- First aids
-    -- [1251] = 6, -- linen Bandage
-    -- [2581] = 6, -- Heavy Linen Bandage
-    -- [3530] = 7, --  Wool Bandage
-    -- [3531] = 7, -- Heavy Wool Bandage
-    [21991] = 8, -- Silk Bandage
+
+	--== Warlock ==--
+	[1120]	= 5, -- Drain Soul
+	[689] 	= 5, -- Drain Life
+	[5138]	= 5, -- Drain Mana
+	[5740]	= 4, -- Rain of Fire
+	[755]	= 10, -- Health Funnel
+	[1949]	= 15, -- Hellfire
+
+	--== Druid ==--
+	[740]	= 4, -- Tranquility
+	[16914]	= 10, -- Hurricane
+
+	--== Priest ==--
+	[15407] = 3, -- Mind Flay
+	
+	--== Mage ==--
+	[10]	= 8, -- Blizzard
+	[12051]	= 4, -- Evocation
+	-- Arcane Missiles ticks are done per rank in the code below.
+
+	--== Hunter ==--
+	[1510]	= 6, -- Volley
+
 }
 
 
-local function getChannelingTicks(spell, spellid)
-    if not db.profile.showticks then
-        return 0
-    end
+--===== Function that sets a spell tick =====--
 
-    if not channelingTicks then
-        channelingTicks = {}
-        for k,v in pairs(channelData) do
-            if type(k) == "number" then
-                channelingTicks[k] = v
-            else
-                local itemName, _, _, _, _, _, _, _, _, _, _ = GetItemInfo(k)
-                if itemName then
-                    channelingTicks[itemName] = v
-                else
-                    local spellName, _, _, _, _, _, _, _, _, _, _ = GetSpellInfo(k)
-                    if spellName then
-                        channelingTicks[spellName] = v
-                    end
-                end
-            end
-        end
-    end
+local function getChannelingTicks(spell)
+	if not db.profile.showticks then
+		return 0
+	end
+	if not channelingTicks then
+		channelingTicks = {}
+		for k,v in pairs(channelData) do
+			if type(k) == "number" then
+				channelingTicks[(GetSpellInfo(k))] = v
+			else
+				channelingTicks[k] = v
+			end
+		end
+	end
 
-    return channelingTicks[spell] or channelingTicks[spellid] or 0
+
+	--===== Locales for different client languages of Arcane Missiles/First Aid. =====--
+
+	local Locale = {}
+	if GetLocale() == "enUS" or GetLocale() == "enGB" then
+		Locale["Rank 1"] = "Rank 1"
+		Locale["Rank 2"] = "Rank 2"
+		Locale["Rank 3"] = "Rank 3"
+		Locale["Rank 4"] = "Rank 4"
+
+	elseif GetLocale() == "ruRU" then
+		Locale["Rank 1"] = "Уровень 1"
+		Locale["Rank 2"] = "Уровень 2"
+		Locale["Rank 3"] = "Уровень 3"
+		Locale["Rank 4"] = "Уровень 4"
+
+	elseif GetLocale() == "frFR" then
+		Locale["Rank 1"] = "Rang 1"
+		Locale["Rank 2"] = "Rang 2"
+		Locale["Rank 3"] = "Rang 3"
+		Locale["Rank 4"] = "Rang 4"
+
+	end
+
+
+	--===== Arcane Missiles Ticks =====--
+
+	local arcaneMissilesSpellId = 5143 -- Global spell ID for Arcane Missiles
+	-- Check if Player is a MAGE. --
+	local _, class = UnitClass("player")
+	if class == "MAGE" and spell == GetSpellInfo(arcaneMissilesSpellId) then
+		-- Get INFO from current channeling.
+		local name, rank, _, _, ChannelStartTime, ChannelEndTime = UnitChannelInfo("player")
+		if name == spell then
+			local castTime = (ChannelEndTime - ChannelStartTime) / 1000
+			local ticks = 0
+			if rank == Locale["Rank 1"] then
+				ticks = 3
+				setBarTicks(0)
+				-- print("3 ticks")
+			elseif rank == Locale["Rank 2"] then
+				ticks = 4
+				setBarTicks(0)
+				-- print("4 ticks")
+			else
+				ticks = 5
+				setBarTicks(0)
+				-- print("5 ticks")				
+			end
+			return ticks
+		end
+	end
+
+
+	--===== First Aid aka Bandage Ticks =====--
+
+	local firstAidSpellId = 746 -- Global spell ID for First Aid
+	if spell == GetSpellInfo(firstAidSpellId) then
+		local name, rank, _, _, ChannelStartTime, ChannelEndTime = UnitChannelInfo("player")
+		if name == spell then
+			local castTime = (ChannelEndTime - ChannelStartTime) / 1000
+			local ticks = 0
+			if rank == Locale["Rank 1"] or rank == Locale["Rank 2"] then
+				ticks = 6
+				setBarTicks(0)
+			elseif rank == Locale["Rank 3"] or rank == Locale["Rank 4"] then
+				ticks = 7
+				setBarTicks(0)
+			else
+				ticks = 8
+				setBarTicks(0)
+			end
+			return ticks
+		end
+	end
+
+return channelingTicks[spell] or 0
 end
+
+
+
+----------------------------------------------------------------------
+--	Events.
+----------------------------------------------------------------------
+
 
 
 function QuartzPlayer:UNIT_SPELLCAST_CHANNEL_START(unit)
@@ -465,7 +572,7 @@ function QuartzPlayer:UNIT_SPELLCAST_CHANNEL_START(unit)
 	self.casting = nil
 	self.channeling = true
 	--FixMe: How do we work this out?
-	self.channelingTicks = getChannelingTicks( spell )
+	self.channelingTicks = getChannelingTicks(spell)
 	self.fadeOut = nil
 	
 	setBarTicks(self.channelingTicks)
@@ -530,7 +637,7 @@ function QuartzPlayer:UNIT_SPELLCAST_CHANNEL_STOP(unit)
 end
 
 function QuartzPlayer:UNIT_SPELLCAST_FAILED(unit)
-	if unit ~= 'player' or self.channeling then
+	if unit ~= 'player' or self.channeling or self.casting then
 		return
 	end
 	if UnitCastingInfo(unit) or UnitChannelInfo(unit) then return end
@@ -703,62 +810,65 @@ do
 					castBarText:SetPoint('CENTER', castBar, 'CENTER', db.nametextx, db.nametexty)
 					castBarText:SetJustifyH("CENTER")
 				else -- L["Right"]
-					castBarText:SetPoint('RIGHT', castBar, 'RIGHT', -1 * db.nametextx, db.nametexty)
-					castBarText:SetJustifyH("RIGHT")
-					if db.hidetimetext or db.timetextposition ~= L["Left"] then
-						castBarText:SetWidth(db.w)
-					else
-						castBarText:SetWidth(db.w - normaltimewidth - 5)
-					end
+				castBarText:SetPoint('RIGHT', castBar, 'RIGHT', -1 * db.nametextx, db.nametexty)
+				castBarText:SetJustifyH("RIGHT")
+				if db.hidetimetext or db.timetextposition ~= L["Left"] then
+					castBarText:SetWidth(db.w)
+				else
+					castBarText:SetWidth(db.w - normaltimewidth - 5)
 				end
-			end
-			castBarText:SetFont(media:Fetch('font', db.font), db.fontsize)
-			castBarText:SetShadowColor( 0, 0, 0, 1)
-			castBarText:SetShadowOffset( 0.8, -0.8 )
-			castBarText:SetTextColor(unpack(Quartz.db.profile.spelltextcolor))
-			castBarText:SetNonSpaceWrap(false)
-			castBarText:SetHeight(db.h)
-			
-			if db.hideicon then
-				castBarIcon:Hide()
-			else
-				castBarIcon:Show()
-				castBarIcon:ClearAllPoints()
-				if db.iconposition == L["Left"] then
-					castBarIcon:SetPoint("RIGHT", castBar, "LEFT", -1 * db.icongap, 0)
-				else --L["Right"]
-					castBarIcon:SetPoint("LEFT", castBar, "RIGHT", db.icongap, 0)
-				end
-				castBarIcon:SetWidth(db.h)
-				castBarIcon:SetHeight(db.h)
-				castBarIcon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
-				castBarIcon:SetAlpha(db.iconalpha)
-			end
-			
-			castBarSpark:SetTexture("Interface\\CastingBar\\UI-CastingBar-Spark")
-			castBarSpark:SetVertexColor(unpack(Quartz.db.profile.sparkcolor))
-			castBarSpark:SetBlendMode('ADD')
-			castBarSpark:SetWidth(20)
-			castBarSpark:SetHeight(db.h*2.2)
-			
-			if db.hideblizz then
-				CastingBarFrame.RegisterEvent = nothing
-				CastingBarFrame:UnregisterAllEvents()
-				CastingBarFrame:Hide()
-			else
-				CastingBarFrame.RegisterEvent = nil
-				CastingBarFrame:UnregisterAllEvents()
-				CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_START")
-				CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_STOP")
-				CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_FAILED")
-				CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED")
-				CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_DELAYED")
-				CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
-				CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
-				CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_UPDATE")
 			end
 		end
+		castBarText:SetFont(media:Fetch('font', db.font), db.fontsize)
+		castBarText:SetShadowColor( 0, 0, 0, 1)
+		castBarText:SetShadowOffset( 0.8, -0.8 )
+		castBarText:SetTextColor(unpack(Quartz.db.profile.spelltextcolor))
+		castBarText:SetNonSpaceWrap(false)
+		castBarText:SetHeight(db.h)
+
+		if db.hideicon then
+			castBarIcon:Hide()
+		else
+			castBarIcon:Show()
+			castBarIcon:ClearAllPoints()
+			if db.iconposition == L["Left"] then
+				castBarIcon:SetPoint("RIGHT", castBar, "LEFT", -1 * db.icongap, 0)
+				else --L["Right"]
+				castBarIcon:SetPoint("LEFT", castBar, "RIGHT", db.icongap, 0)
+			end
+			castBarIcon:SetWidth(db.h)
+			castBarIcon:SetHeight(db.h)
+			castBarIcon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
+			castBarIcon:SetAlpha(db.iconalpha)
+		end
+
+
+		--===== Setup the SparkVisual look. =====--
+
+		castBarSpark:SetTexture("Interface\\CastingBar\\UI-CastingBar-Spark")
+		castBarSpark:SetVertexColor(unpack(Quartz.db.profile.sparkcolor))
+		castBarSpark:SetBlendMode('ADD')
+		castBarSpark:SetWidth(20)
+		castBarSpark:SetHeight(db.h*2.2)
+
+		if db.hideblizz then
+			CastingBarFrame.RegisterEvent = nothing
+			CastingBarFrame:UnregisterAllEvents()
+			CastingBarFrame:Hide()
+		else
+			CastingBarFrame.RegisterEvent = nil
+			CastingBarFrame:UnregisterAllEvents()
+			CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_START")
+			CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_STOP")
+			CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_FAILED")
+			CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED")
+			CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_DELAYED")
+			CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
+			CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
+			CastingBarFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_UPDATE")
+		end
 	end
+end
 end
 
 do
@@ -858,377 +968,377 @@ do
 				-- passValue = 'showticks',
 				-- order = 102,
 				--	},
-			h = {
-				type = 'range',
-				name = L["Height"],
-				desc = L["Height"],
-				min = 10,
-				max = 50,
-				step = 1,
-				order = 200,
-				get = get,
-				set = set,
-				passValue = 'h',
-			},
-			w = {
-				type = 'range',
-				name = L["Width"],
-				desc = L["Width"],
-				min = 50,
-				max = 1500,
-				step = 5,
-				order = 200,
-				get = get,
-				set = set,
-				passValue = 'w',
-			},
-			x = {
-				type = 'text',
-				name = L["X"],
-				desc = L["Set an exact X value for this bar's position."],
-				get = get,
-				set = set,
-				passValue = 'x',
-				order = 200,
-				validate = function(v)
-					return tonumber(v) and true
-				end,
-				usage = L["Number"],
-			},
-			y = {
-				type = 'text',
-				name = L["Y"],
-				desc = L["Set an exact Y value for this bar's position."],
-				get = get,
-				set = set,
-				passValue = 'y',
-				order = 200,
-				validate = function(v)
-					return tonumber(v) and true
-				end,
-				usage = L["Number"],
-			},
-			scale = {
-				type = 'range',
-				name = L["Scale"],
-				desc = L["Scale"],
-				min = 0.2,
-				max = 1,
-				step = 0.025,
-				order = 201,
-				get = get,
-				set = set,
-				passValue = 'scale',
-			},
-			alpha = {
-				type = 'range',
-				name = L["Alpha"],
-				desc = L["Alpha"],
-				isPercent = true,
-				min = 0.1,
-				max = 1,
-				step = 0.025,
-				order = 202,
-				get = get,
-				set = set,
-				passValue = 'alpha',
-			},
-			header2 = {
-				type = 'header',
-				order = 203,
-			},
-			hideicon = {
-				type = 'toggle',
-				name = L["Hide Icon"],
-				desc = L["Hide Spell Cast Icon"],
-				get = get,
-				set = set,
-				passValue = 'hideicon',
-				order = 301,
-			},
-			iconalpha = {
-				type = 'range',
-				name = L["Icon Alpha"],
-				desc = L["Set the Spell Cast icon alpha"],
-				isPercent = true,
-				min = 0.1,
-				max = 1,
-				step = 0.025,
-				order = 301,
-				get = get,
-				set = set,
-				disabled = hideiconoptions,
-				passValue = 'iconalpha',
-			},
-			iconposition = {
-				type = 'text',
-				name = L["Icon Position"],
-				desc = L["Set where the Spell Cast icon appears"],
-				get = get,
-				set = set,
-				disabled = hideiconoptions,
-				passValue = 'iconposition',
-				validate = {L["Left"], L["Right"]},
-				order = 301,
-			},
-			icongap = {
-				type = 'range',
-				name = L["Icon Gap"],
-				desc = L["Space between the cast bar and the icon."],
-				min = -35,
-				max = 35,
-				step = 1,
-				order = 301,
-				get = get,
-				set = set,
-				disabled = hideiconoptions,
-				passValue = 'icongap',
-			},
-			texture = {
-				type = 'text',
-				name = L["Texture"],
-				desc = L["Set the Cast Bar Texture"],
-				validate = media:List('statusbar'),
-				order = 302,
-				get = get,
-				set = set,
-				passValue = 'texture',
-			},
-			font = {
-				type = 'text',
-				name = L["Font"],
-				desc = L["Set the font used in the Name and Time texts"],
-				validate = media:List('font'),
-				order = 400,
-				get = get,
-				set = set,
-				passValue = 'font',
-			},
-			hidenametext = {
-				type = 'toggle',
-				name = L["Hide Name Text"],
-				desc = L["Disable the text that displays the spell name/rank"],
-				get = get,
-				set = set,
-				passValue = 'hidenametext',
-				order = 401,
-			},
-			nametextposition = {
-				type = 'text',
-				name = L["Name Text Position"],
-				desc = L["Set the alignment of the spell name text"],
-				get = get,
-				set = set,
-				passValue = 'nametextposition',
-				validate = {L["Left"], L["Right"], L["Center"]},
-				disabled = hidenametextoptions,
-				order = 402,
-			},
-			nametextx = {
-				type = 'range',
-				name = L["Name Text X Offset"],
-				desc = L["Adjust the X position of the name text"],
-				get = get,
-				set = set,
-				passValue = 'nametextx',
-				min = -35,
-				max = 35,
-				step = 1,
-				disabled = hidenametextoptions,
-				order = 402,
-			},
-			nametexty = {
-				type = 'range',
-				name = L["Name Text Y Offset"],
-				desc = L["Adjust the Y position of the name text"],
-				get = get,
-				set = set,
-				passValue = 'nametexty',
-				min = -35,
-				max = 35,
-				step = 1,
-				disabled = hidenametextoptions,
-				order = 402,
-			},
-			namefontsize = {
-				type = 'range',
-				name = L["Name Text Font Size"],
-				desc = L["Set the size of the spell name text"],
-				min = 7,
-				max = 20,
-				step = 1,
-				order = 403,
-				get = get,
-				set = set,
-				disabled = hidenametextoptions,
-				passValue = 'fontsize',
-			},
-			targetname = {
-				type = 'toggle',
-				name = L["Target Name"],
-				desc = L["Display target name of spellcasts after spell name"],
-				get = get,
-				set = set,
-				passValue = 'targetname',
-				order = 404,
-			},			
-			spellrank = {
-				type = 'toggle',
-				name = L["Spell Rank"],
-				desc = L["Display the rank of spellcasts alongside their name"],
-				get = get,
-				set = set,
-				disabled = hidenametextoptions,
-				passValue = 'spellrank',
-				order = 405,
-			},
-			spellrankstyle = {
-				type = 'text',
-				name = L["Spell Rank Style"],
-				desc = L["Set the display style of the spell rank"],
-				get = get,
-				set = set,
-				disabled = function()
-					return db.profile.hidenametext or not db.profile.spellrank
-				end,
-				passValue = 'spellrankstyle',
-				validate = {L["Number"], L["Roman"], L["Full Text"], L["Roman Full Text"]},
-				order = 406,
-			},
-			hidetimetext = {
-				type = 'toggle',
-				name = L["Hide Time Text"],
-				desc = L["Disable the text that displays the time remaining on your cast"],
-				get = get,
-				set = set,
-				passValue = 'hidetimetext',
-				order = 411,
-			},
-			hidecasttime = {
-				type = 'toggle',
-				name = L["Hide Cast Time"],
-				desc = L["Disable the text that displays the total cast time"],
-				get = get,
-				set = set,
-				passValue = 'hidecasttime',
-				disabled = hidetimetextoptions,
-				order = 412,
-			},
-			casttimeprecision = {
-				type = 'range',
-				name = L["Cast Time Precision"],
-				desc = L["Set the precision (i.e. number of decimal places) for the cast time text"],
-				min = 1,
-				max = 3,
-				step = 1,
-				order = 413,
-				get = get,
-				set = set,
-				disabled = hidecasttimeprecision,
-				passValue = 'casttimeprecision',
-			},
-			timefontsize = {
-				type = 'range',
-				name = L["Time Font Size"],
-				desc = L["Set the size of the time text"],
-				min = 7,
-				max = 20,
-				step = 1,
-				order = 414,
-				get = get,
-				set = set,
-				disabled = hidetimetextoptions,
-				passValue = 'timefontsize',
-			},
-			timetextposition = {
-				type = 'text',
-				name = L["Time Text Position"],
-				desc = L["Set the alignment of the time text"],
-				get = get,
-				set = set,
-				passValue = 'timetextposition',
-				validate = {L["Left"], L["Right"], L["Center"], L["Cast Start Side"], L["Cast End Side"]},
-				disabled = hidetimetextoptions,
-				order = 415,
-			},
-			timetextx = {
-				type = 'range',
-				name = L["Time Text X Offset"],
-				desc = L["Adjust the X position of the time text"],
-				get = get,
-				set = set,
-				passValue = 'timetextx',
-				min = -35,
-				max = 35,
-				step = 1,
-				disabled = hidetimetextoptions,
-				order = 416,
-			},
-			timetexty = {
-				type = 'range',
-				name = L["Time Text Y Offset"],
-				desc = L["Adjust the Y position of the time text"],
-				get = get,
-				set = set,
-				passValue = 'timetexty',
-				min = -35,
-				max = 35,
-				step = 1,
-				disabled = hidetimetextoptions,
-				order = 417,
-			},
-			header4 = {
-				type = 'header',
-				order = 418,
-			},
-			border = {
-				type = 'text',
-				name = L["Border"],
-				desc = L["Set the border style"],
-				get = get,
-				set = set,
-				passValue = 'border',
-				validate = media:List('border'),
-				order = 418,
-			},
-			header6 = {
-				type = 'header',
-				order = 501,
-			},
-			snaptocenter = {
-				type = 'text',
-				name = L["Snap to Center"],
-				desc = L["Move the CastBar to center of the screen along the specified axis"],
-				get = false,
-				set = function(v)
-					local scale = db.profile.scale
-					if v == L["Horizontal"] then
-						db.profile.x = (UIParent:GetWidth() / 2 - (db.profile.w * scale) / 2) / scale
+				h = {
+					type = 'range',
+					name = L["Height"],
+					desc = L["Height"],
+					min = 10,
+					max = 50,
+					step = 1,
+					order = 200,
+					get = get,
+					set = set,
+					passValue = 'h',
+				},
+				w = {
+					type = 'range',
+					name = L["Width"],
+					desc = L["Width"],
+					min = 50,
+					max = 1500,
+					step = 5,
+					order = 200,
+					get = get,
+					set = set,
+					passValue = 'w',
+				},
+				x = {
+					type = 'text',
+					name = L["X"],
+					desc = L["Set an exact X value for this bar's position."],
+					get = get,
+					set = set,
+					passValue = 'x',
+					order = 200,
+					validate = function(v)
+						return tonumber(v) and true
+					end,
+					usage = L["Number"],
+				},
+				y = {
+					type = 'text',
+					name = L["Y"],
+					desc = L["Set an exact Y value for this bar's position."],
+					get = get,
+					set = set,
+					passValue = 'y',
+					order = 200,
+					validate = function(v)
+						return tonumber(v) and true
+					end,
+					usage = L["Number"],
+				},
+				scale = {
+					type = 'range',
+					name = L["Scale"],
+					desc = L["Scale"],
+					min = 0.2,
+					max = 1,
+					step = 0.025,
+					order = 201,
+					get = get,
+					set = set,
+					passValue = 'scale',
+				},
+				alpha = {
+					type = 'range',
+					name = L["Alpha"],
+					desc = L["Alpha"],
+					isPercent = true,
+					min = 0.1,
+					max = 1,
+					step = 0.025,
+					order = 202,
+					get = get,
+					set = set,
+					passValue = 'alpha',
+				},
+				header2 = {
+					type = 'header',
+					order = 203,
+				},
+				hideicon = {
+					type = 'toggle',
+					name = L["Hide Icon"],
+					desc = L["Hide Spell Cast Icon"],
+					get = get,
+					set = set,
+					passValue = 'hideicon',
+					order = 301,
+				},
+				iconalpha = {
+					type = 'range',
+					name = L["Icon Alpha"],
+					desc = L["Set the Spell Cast icon alpha"],
+					isPercent = true,
+					min = 0.1,
+					max = 1,
+					step = 0.025,
+					order = 301,
+					get = get,
+					set = set,
+					disabled = hideiconoptions,
+					passValue = 'iconalpha',
+				},
+				iconposition = {
+					type = 'text',
+					name = L["Icon Position"],
+					desc = L["Set where the Spell Cast icon appears"],
+					get = get,
+					set = set,
+					disabled = hideiconoptions,
+					passValue = 'iconposition',
+					validate = {L["Left"], L["Right"]},
+					order = 301,
+				},
+				icongap = {
+					type = 'range',
+					name = L["Icon Gap"],
+					desc = L["Space between the cast bar and the icon."],
+					min = -35,
+					max = 35,
+					step = 1,
+					order = 301,
+					get = get,
+					set = set,
+					disabled = hideiconoptions,
+					passValue = 'icongap',
+				},
+				texture = {
+					type = 'text',
+					name = L["Texture"],
+					desc = L["Set the Cast Bar Texture"],
+					validate = media:List('statusbar'),
+					order = 302,
+					get = get,
+					set = set,
+					passValue = 'texture',
+				},
+				font = {
+					type = 'text',
+					name = L["Font"],
+					desc = L["Set the font used in the Name and Time texts"],
+					validate = media:List('font'),
+					order = 400,
+					get = get,
+					set = set,
+					passValue = 'font',
+				},
+				hidenametext = {
+					type = 'toggle',
+					name = L["Hide Name Text"],
+					desc = L["Disable the text that displays the spell name/rank"],
+					get = get,
+					set = set,
+					passValue = 'hidenametext',
+					order = 401,
+				},
+				nametextposition = {
+					type = 'text',
+					name = L["Name Text Position"],
+					desc = L["Set the alignment of the spell name text"],
+					get = get,
+					set = set,
+					passValue = 'nametextposition',
+					validate = {L["Left"], L["Right"], L["Center"]},
+					disabled = hidenametextoptions,
+					order = 402,
+				},
+				nametextx = {
+					type = 'range',
+					name = L["Name Text X Offset"],
+					desc = L["Adjust the X position of the name text"],
+					get = get,
+					set = set,
+					passValue = 'nametextx',
+					min = -35,
+					max = 35,
+					step = 1,
+					disabled = hidenametextoptions,
+					order = 402,
+				},
+				nametexty = {
+					type = 'range',
+					name = L["Name Text Y Offset"],
+					desc = L["Adjust the Y position of the name text"],
+					get = get,
+					set = set,
+					passValue = 'nametexty',
+					min = -35,
+					max = 35,
+					step = 1,
+					disabled = hidenametextoptions,
+					order = 402,
+				},
+				namefontsize = {
+					type = 'range',
+					name = L["Name Text Font Size"],
+					desc = L["Set the size of the spell name text"],
+					min = 7,
+					max = 20,
+					step = 1,
+					order = 403,
+					get = get,
+					set = set,
+					disabled = hidenametextoptions,
+					passValue = 'fontsize',
+				},
+				targetname = {
+					type = 'toggle',
+					name = L["Target Name"],
+					desc = L["Display target name of spellcasts after spell name"],
+					get = get,
+					set = set,
+					passValue = 'targetname',
+					order = 404,
+				},			
+				spellrank = {
+					type = 'toggle',
+					name = L["Spell Rank"],
+					desc = L["Display the rank of spellcasts alongside their name"],
+					get = get,
+					set = set,
+					disabled = hidenametextoptions,
+					passValue = 'spellrank',
+					order = 405,
+				},
+				spellrankstyle = {
+					type = 'text',
+					name = L["Spell Rank Style"],
+					desc = L["Set the display style of the spell rank"],
+					get = get,
+					set = set,
+					disabled = function()
+						return db.profile.hidenametext or not db.profile.spellrank
+					end,
+					passValue = 'spellrankstyle',
+					validate = {L["Number"], L["Roman"], L["Full Text"], L["Roman Full Text"]},
+					order = 406,
+				},
+				hidetimetext = {
+					type = 'toggle',
+					name = L["Hide Time Text"],
+					desc = L["Disable the text that displays the time remaining on your cast"],
+					get = get,
+					set = set,
+					passValue = 'hidetimetext',
+					order = 411,
+				},
+				hidecasttime = {
+					type = 'toggle',
+					name = L["Hide Cast Time"],
+					desc = L["Disable the text that displays the total cast time"],
+					get = get,
+					set = set,
+					passValue = 'hidecasttime',
+					disabled = hidetimetextoptions,
+					order = 412,
+				},
+				casttimeprecision = {
+					type = 'range',
+					name = L["Cast Time Precision"],
+					desc = L["Set the precision (i.e. number of decimal places) for the cast time text"],
+					min = 1,
+					max = 3,
+					step = 1,
+					order = 413,
+					get = get,
+					set = set,
+					disabled = hidecasttimeprecision,
+					passValue = 'casttimeprecision',
+				},
+				timefontsize = {
+					type = 'range',
+					name = L["Time Font Size"],
+					desc = L["Set the size of the time text"],
+					min = 7,
+					max = 20,
+					step = 1,
+					order = 414,
+					get = get,
+					set = set,
+					disabled = hidetimetextoptions,
+					passValue = 'timefontsize',
+				},
+				timetextposition = {
+					type = 'text',
+					name = L["Time Text Position"],
+					desc = L["Set the alignment of the time text"],
+					get = get,
+					set = set,
+					passValue = 'timetextposition',
+					validate = {L["Left"], L["Right"], L["Center"], L["Cast Start Side"], L["Cast End Side"]},
+					disabled = hidetimetextoptions,
+					order = 415,
+				},
+				timetextx = {
+					type = 'range',
+					name = L["Time Text X Offset"],
+					desc = L["Adjust the X position of the time text"],
+					get = get,
+					set = set,
+					passValue = 'timetextx',
+					min = -35,
+					max = 35,
+					step = 1,
+					disabled = hidetimetextoptions,
+					order = 416,
+				},
+				timetexty = {
+					type = 'range',
+					name = L["Time Text Y Offset"],
+					desc = L["Adjust the Y position of the time text"],
+					get = get,
+					set = set,
+					passValue = 'timetexty',
+					min = -35,
+					max = 35,
+					step = 1,
+					disabled = hidetimetextoptions,
+					order = 417,
+				},
+				header4 = {
+					type = 'header',
+					order = 418,
+				},
+				border = {
+					type = 'text',
+					name = L["Border"],
+					desc = L["Set the border style"],
+					get = get,
+					set = set,
+					passValue = 'border',
+					validate = media:List('border'),
+					order = 418,
+				},
+				header6 = {
+					type = 'header',
+					order = 501,
+				},
+				snaptocenter = {
+					type = 'text',
+					name = L["Snap to Center"],
+					desc = L["Move the CastBar to center of the screen along the specified axis"],
+					get = false,
+					set = function(v)
+						local scale = db.profile.scale
+						if v == L["Horizontal"] then
+							db.profile.x = (UIParent:GetWidth() / 2 - (db.profile.w * scale) / 2) / scale
 					else -- L["Vertical"]
-						db.profile.y = (UIParent:GetHeight() / 2 - (db.profile.h * scale) / 2) / scale
-					end
-					Quartz.ApplySettings()
-				end,
-				validate = {L["Horizontal"], L["Vertical"]},
-				order = 503,
-			},
-			copysettings = {
-				type = 'text',
-				name = L["Copy Settings From"],
-				desc = L["Select a bar from which to copy settings"],
-				get = false,
-				set = function(v)
-					local from = Quartz:AcquireDBNamespace(v)
-					Quartz:CopySettings(from.profile, db.profile)
-					Quartz.ApplySettings()
-				end,
-				validate = {L["Target"], L["Focus"], L["Pet"]},
-				order = 504
-			},
-			header6 = {
-				type = 'header',
-				order = 505,
-			},
+					db.profile.y = (UIParent:GetHeight() / 2 - (db.profile.h * scale) / 2) / scale
+				end
+				Quartz.ApplySettings()
+			end,
+			validate = {L["Horizontal"], L["Vertical"]},
+			order = 503,
 		},
-	}
+		copysettings = {
+			type = 'text',
+			name = L["Copy Settings From"],
+			desc = L["Select a bar from which to copy settings"],
+			get = false,
+			set = function(v)
+				local from = Quartz:AcquireDBNamespace(v)
+				Quartz:CopySettings(from.profile, db.profile)
+				Quartz.ApplySettings()
+			end,
+			validate = {L["Target"], L["Focus"], L["Pet"]},
+			order = 504
+		},
+		header6 = {
+			type = 'header',
+			order = 505,
+		},
+	},
+}
 end

--- a/Quartz/Quartz.lua
+++ b/Quartz/Quartz.lua
@@ -106,6 +106,9 @@ function Quartz:OnInitialize()
 	self:RegisterDefaults("profile", {
 		hidesamwise = true,
 		
+	    tickalpha = {
+	        ["value"] = 0.7,
+	    },
 		sparkcolor = {1,1,1,0.5},
 		spelltextcolor = {1, 1, 1},
 		timetextcolor = {1, 1, 1},
@@ -361,6 +364,22 @@ do
 						set = set,
 						passValue = 'borderalpha',
 						order = 104,
+					},
+					tickalpha = {
+						type = 'range',
+						name = "Tick Alpha",
+						desc = "Set the alpha of the casting bar ticks",
+						isPercent = true,
+						min = 0,
+						max = 1,
+						step = 0.025,
+			            get = function(info)
+			                return self.db.profile.tickalpha.value
+			            end,
+			            set = function(info, value)
+			                self.db.profile.tickalpha.value = value end,
+						passValue = 'tickalpha.value',
+						order = 105,
 					},
 				},
 			}


### PR DESCRIPTION
add ticks for the castbar, with rank check for bandage, arcane missiles. add animation to ticks (fade-in)
make alpha of ticks be adjustable by user in options frame.

quartz.lua doesnt have that much changes, it's just my Sublime 3 Text editor made another identation and therefore its so many additions, because of white spaces.

![quartz-ticks](https://user-images.githubusercontent.com/74269253/236645168-077cb148-c71c-4bfb-a7a2-865da06a661b.gif)

![optionstick](https://user-images.githubusercontent.com/74269253/236645174-90fe28f3-61d0-49d8-b3f2-00504b021716.png)
